### PR TITLE
docs(trace): add TractionBatteryCode aspect model

### DIFF
--- a/docs/kits/Traceability Kit/Software Development View/page_software-development-view.md
+++ b/docs/kits/Traceability Kit/Software Development View/page_software-development-view.md
@@ -296,6 +296,68 @@ Github Link to semantic data model: [https://github.com/eclipse-tractusx/sldt-se
 
 > Please note that if a just-in-sequence part is also a serialized part SerialPartTypization should be used instead.
 
+#### Submodel TractionBatteryCode
+
+Github Link to semantic data model: [https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.traction_battery_code/1.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.traction_battery_code/1.0.0)
+
+##### Submodel "TractionBatteryCode" for a Battery Module
+
+```json
+{
+  "productType": "module",
+  "tractionBatteryCode": "B54MCPM27KLPCLE6A7519857",
+  "subcomponents": [
+    {
+      "productType": "cell",
+      "tractionBatteryCode": "X12CCPM27KLPCLE662382320"
+    },
+    {
+      "productType": "cell",
+      "tractionBatteryCode": "X12CCPM27KLPCLE662382321"
+    }
+  ]
+}
+```
+
+##### Submodel "TractionBatteryCode" for a Battery Pack
+
+```json
+{
+  "productType": "pack",
+  "tractionBatteryCode": "4A6PCPM27KLPCLE742946319",
+  "subcomponents": [
+    {
+      "productType": "module",
+      "tractionBatteryCode": "B54MCPM27KLPCLE6A7519857",
+      "subcomponents": [
+        {
+          "productType": "cell",
+          "tractionBatteryCode": "X12CCPM27KLPCLE662382320"
+        },
+        {
+          "productType": "cell",
+          "tractionBatteryCode": "X12CCPM27KLPCLE662382321"
+        }
+      ]
+    },
+    {
+      "productType": "module",
+      "tractionBatteryCode": "B54MCPM27KLPCLE6A7519858",
+      "subcomponents": [
+        {
+          "productType": "cell",
+          "tractionBatteryCode": "X12CCPM27KLPCLE662382322"
+        },
+        {
+          "productType": "cell",
+          "tractionBatteryCode": "X12CCPM27KLPCLE662382323"
+        }
+      ]
+    }
+  ]
+}
+```
+
 <!-- Recommended -->
 ## Reference Implementation
 

--- a/docs/kits/Traceability Kit/page_adoption-view.md
+++ b/docs/kits/Traceability Kit/page_adoption-view.md
@@ -198,6 +198,7 @@ Defined
   - Aspect model "AssemblyPartRelation"
   - Aspect model "Batch"
   - Aspect model "JustInSequencePart"
+  - Aspect model "TractionBatteryCode"
 
 ### AsBuilt Aspect Models
 
@@ -224,6 +225,13 @@ Github Link to semantic data model: [https://github.com/eclipse-tractusx/sldt-se
 A just-in-sequence part is an instantiation of a (design-) part, where the particular instantiation can be uniquely identified by means of a combination of several IDs related to a just-in-sequence process.
 
 Github Link to semantic data model: [https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.just_in_sequence_part/1.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.just_in_sequence_part/1.0.0)
+
+#### 5. TractionBatteryCode
+
+The aspect provides the information of the Traction battery code of a battery cell, a battery module or a battery pack according to the chinese standard GB/T 34014-2017. Furthermore, it provides the traction battery codes for the assembled sub parts of the component, e.g.  Traction battery code of a battery module plus all the traction battery codes of the assembled battery cells of this battery module.
+
+Github Link to semantic data model: [https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.traction_battery_code/1.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.traction_battery_code/1.0.0)
+
 
 <!-- Recommended -->
 ## Logic & Schema
@@ -390,3 +398,4 @@ Our relevant standards can be downloaded from the official [Catena-X Standard Li
 - [CX - 0021 Aspect Model: Batch](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/PLM_Quality_Use_Case_Traceability/CX_-_0021__Batch_UseCaseTraceability_v_1.0.1.pdf)
 - [CX - 0022 Notification Process](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/PLM_Quality_Use_Case_Traceability/CX_-_0022_Notification_Process_v_1.1.1.pdf)
 - [CX - 0023 Notification API](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/PLM_Quality_Use_Case_Traceability/CX_-_0023_Notification_API_v_1.1.1.pdf)
+- [CX - 0093 Aspect Model TractionBatteryCode]

--- a/docs/kits/Traceability Kit/page_changelog.md
+++ b/docs/kits/Traceability Kit/page_changelog.md
@@ -15,7 +15,7 @@ All notable changes to this Kit will be documented in this file.
 
 ### Added
 
-- ./.
+- TractionBatteryCode aspect model
 
 ### Changed
 


### PR DESCRIPTION
This pull request adds information, links, and example payloads of the new TractionBatteryCode aspect model to the traceability KIT.

The link to the standardization document will be added after the standard is released.