### PR TITLE
docs(trace): update license to CC-BY-4.0

### DIFF
--- a/docs-kits/kits/Traceability Kit/Software Development View/page_data-provider_software-development-view.md
+++ b/docs-kits/kits/Traceability Kit/Software Development View/page_data-provider_software-development-view.md
@@ -1114,3 +1114,21 @@ When using an above mentioned [Access Policy](#access-policies), their `id` need
 ### Verifiable Credentials
 
 Verifiable Credentials (VC) are part of the Self-Sovereign Identity (SSI) standard by the W3C. Details about Catena-X specific VCs can be found in the [CX - 0016 Company Attribute Verification](#standards) standard. As mentioned there, it offers a `UseCaseFrameworkConditionCX` type allowing a data provider to check if specific conditions, like a signed use case contract as introduced in the [Purpose-base Usage Policy section](#purpose-based-policy), are agreed. Further technical documentation are presented in the [SSI Docu](https://github.com/eclipse-tractusx/ssi-docu/tree/main/docs/architecture) repository.
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 BASF SE
+- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
+- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 SAP SE
+- SPDX-FileCopyrightText: 2023 Siemens AG
+- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/Traceability%20Kit (latest version)

--- a/docs-kits/kits/Traceability Kit/assets/architecture_level_1.png.license
+++ b/docs-kits/kits/Traceability Kit/assets/architecture_level_1.png.license
@@ -1,20 +1,3 @@
----
-id: Data Consumer Development View Traceability Kit
-title: Data Consumer
-description: "Traceability Kit"
-sidebar_position: 2
----
-
-![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
-
-The following page offers specific developer resources, including payloads and API endpoints for data consumer and app provider. It is important to read the business and architecture view first to understand everything.
-
-## Data Consumer (App Provider)
-
-_Content will be added, soon._
-
-## NOTICE
-
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0

--- a/docs-kits/kits/Traceability Kit/assets/data_provisioning_data_flow.png.license
+++ b/docs-kits/kits/Traceability Kit/assets/data_provisioning_data_flow.png.license
@@ -1,20 +1,3 @@
----
-id: Data Consumer Development View Traceability Kit
-title: Data Consumer
-description: "Traceability Kit"
-sidebar_position: 2
----
-
-![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
-
-The following page offers specific developer resources, including payloads and API endpoints for data consumer and app provider. It is important to read the business and architecture view first to understand everything.
-
-## Data Consumer (App Provider)
-
-_Content will be added, soon._
-
-## NOTICE
-
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0

--- a/docs-kits/kits/Traceability Kit/assets/traceability_customer-journey.png.license
+++ b/docs-kits/kits/Traceability Kit/assets/traceability_customer-journey.png.license
@@ -1,20 +1,3 @@
----
-id: Data Consumer Development View Traceability Kit
-title: Data Consumer
-description: "Traceability Kit"
-sidebar_position: 2
----
-
-![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
-
-The following page offers specific developer resources, including payloads and API endpoints for data consumer and app provider. It is important to read the business and architecture view first to understand everything.
-
-## Data Consumer (App Provider)
-
-_Content will be added, soon._
-
-## NOTICE
-
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0

--- a/docs-kits/kits/Traceability Kit/assets/unique_id_push_process.png.license
+++ b/docs-kits/kits/Traceability Kit/assets/unique_id_push_process.png.license
@@ -1,20 +1,3 @@
----
-id: Data Consumer Development View Traceability Kit
-title: Data Consumer
-description: "Traceability Kit"
-sidebar_position: 2
----
-
-![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
-
-The following page offers specific developer resources, including payloads and API endpoints for data consumer and app provider. It is important to read the business and architecture view first to understand everything.
-
-## Data Consumer (App Provider)
-
-_Content will be added, soon._
-
-## NOTICE
-
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0

--- a/docs-kits/kits/Traceability Kit/page_architecture-view.md
+++ b/docs-kits/kits/Traceability Kit/page_architecture-view.md
@@ -60,3 +60,21 @@ Our relevant standards can be downloaded from the official [Catena-X Standard Li
 - [CX - 0043 Semantic Model: Part AsPlanned](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/PLM_Quality_Use_Case_Traceability/CX_-_0043_Semantic_Model_PartAsPlanned_v_1.0.1.pdf)
 - [CX - 0093 Aspect Model TractionBatteryCode](https://catena-x.net/de/standard-library)
 - [CX - 0094 Aspect Model Part Site Information AsPlanned](https://catena-x.net/de/standard-library)
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 BASF SE
+- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
+- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 SAP SE
+- SPDX-FileCopyrightText: 2023 Siemens AG
+- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/Traceability%20Kit (latest version)

--- a/docs-kits/kits/Traceability Kit/page_business_view.md
+++ b/docs-kits/kits/Traceability Kit/page_business_view.md
@@ -81,3 +81,21 @@ The following video gives an overview of the presented Traceability Use Case.
 
 <!-- Optional -->
 <!-- ## Whitepaper -->
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 BASF SE
+- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
+- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 SAP SE
+- SPDX-FileCopyrightText: 2023 Siemens AG
+- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/Traceability%20Kit (latest version)

--- a/docs-kits/kits/Traceability Kit/page_changelog.md
+++ b/docs-kits/kits/Traceability Kit/page_changelog.md
@@ -33,6 +33,7 @@ Compatible for release 23.12.
 
 - **General:**
   - Restructure from adoption, operation and development view to business, architecture, operation and development view
+  - License KIT to CC-BY-4.0
 - **Business View:**
   - ./.
 - **Architecture View:**
@@ -128,3 +129,21 @@ Compatible for release 3.1.
 ### Removed
 
 - ./.
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 BASF SE
+- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
+- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 SAP SE
+- SPDX-FileCopyrightText: 2023 Siemens AG
+- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/Traceability%20Kit (latest version)

--- a/docs-kits/kits/Traceability Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Traceability Kit/page_software-operation-view.md
@@ -22,3 +22,21 @@ their usage, configuration and deployment, follow these resources:
 - [Trace-X Installation Guide](https://github.com/eclipse-tractusx/traceability-foss/blob/main/frontend/INSTALL.md)
 - [SDE Frontend GitHub Repository](https://github.com/eclipse-tractusx/dft-frontend)
 - [SDE Backend GitHub Repository](https://github.com/eclipse-tractusx/dft-backend)
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 BASF SE
+- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
+- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
+- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
+- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
+- SPDX-FileCopyrightText: 2023 SAP SE
+- SPDX-FileCopyrightText: 2023 Siemens AG
+- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
+- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/Traceability%20Kit (latest version)

--- a/static/video/traceability-video-9min-UT.mp4.license
+++ b/static/video/traceability-video-9min-UT.mp4.license
@@ -1,20 +1,3 @@
----
-id: Data Consumer Development View Traceability Kit
-title: Data Consumer
-description: "Traceability Kit"
-sidebar_position: 2
----
-
-![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
-
-The following page offers specific developer resources, including payloads and API endpoints for data consumer and app provider. It is important to read the business and architecture view first to understand everything.
-
-## Data Consumer (App Provider)
-
-_Content will be added, soon._
-
-## NOTICE
-
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
According to [TRG 7.08](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-08), the license of the KIT is changed to CC-BY-4.0.