### PR TITLE
docs: update operation view for industry core and traceability kit

### DIFF
--- a/docs-kits/kits/Industry Core Kit/page_software-operation-view.mdx
+++ b/docs-kits/kits/Industry Core Kit/page_software-operation-view.mdx
@@ -27,4 +27,12 @@ import Notice from './part_notice.mdx'
 
 The following page offers information on how to operate and deploy the Industry Core.
 
+Since the Industry Core is a baseline and enablement for other use cases, it doesn't offer one specific application that
+fullfills all functions. For the data provisioning part, the open source solution of the **Simple Data Exchanger (SDE)**
+for data provisioning can be used. Further information regarding their usage, configuration and deployment are published
+on GitHub:
+
+- [SDE Frontend GitHub Repository](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend)
+- [SDE Backend GitHub Repository](https://github.com/eclipse-tractusx/managed-simple-data-exchanger-backend)
+
 <Notice components={props.components} />

--- a/docs-kits/kits/Traceability Kit/page_software-operation-view.mdx
+++ b/docs-kits/kits/Traceability Kit/page_software-operation-view.mdx
@@ -15,16 +15,10 @@ Operation View  of the Kit.
 The following page offers information on how to operate and deploy a Traceability application.
 
 Based on the information provided in this KIT, it is possible to create and operate an own, custom
-Traceability app. One open-source example is the **Trace-X app** in conjunction with the **Simple
-Data Exchanger (SDE)** for data provisioning. For further information regarding
+Traceability app. One open-source example is the **Trace-X app**. For further information regarding
 their usage, configuration and deployment, follow these resources:
 
-- [Trace-X Frontend GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss)
-- [Trace-X Backend GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss-backend)
+- [Trace-X GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss)
 - [Trace-X Installation Guide](https://github.com/eclipse-tractusx/traceability-foss/blob/main/frontend/INSTALL.md)
-- [SDE Frontend GitHub Repository](https://github.com/eclipse-tractusx/dft-frontend)
-- [SDE Backend GitHub Repository](https://github.com/eclipse-tractusx/dft-backend)
-
 
 <Notice components={props.components} />
-


### PR DESCRIPTION
This PR updates the operation view for the industry core and the traceability KIT.