### PR TITLE
Initial changes for Upstream Visibility

### DIFF
--- a/docs-kits/kits/Industry Core Kit/Software Development View/page_aspect-models.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/page_aspect-models.mdx
@@ -130,7 +130,53 @@ Aspect model in GitHub:
   } ]
 }
 ```
+### SingelLevelUsageAsPlanned
 
+The aspect provides the information in which parent part(s)/product(s) the given item is to be assembled into or used. This could be a 1:1 relationship in terms of e.g. a brake component or 1:n for e.g. coatings. The given item as well as the parent item must refer to an object from the as planned lifecycle phase. If one input product is regarded as an alternative to another input product (from same or different supplier), the relation should still be built, but marked with "IsOnlyPotentialParent".
+
+Aspect model in GitHub:
+- Version 1.1.0: https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_usage_as_planned/1.1.0
+
+
+##### Example: Submodel `SingleLevelUsageAsPlanned` for a Catalog Part
+
+```json
+{
+  "parentParts": [
+    {
+      "parentCatenaXId": "urn:uuid:c8B01D5A-ce0B-6Dd4-5bA0-A3e3fcE9cA93",
+      "quantity": {
+        "quantityNumber": 2.5,
+        "measurementUnit": "unit:litre"
+      },
+      "createdOn": "2022-02-03T14:48:54.709Z",
+      "lastModifiedOn": "2022-02-03T14:48:54.709Z"
+    }
+  ],
+  "catenaXId": "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d"
+}
+```
+#### Creation of Aspect Model SingleLevelUsageAsPlanned
+
+The SingleLevelUsageAsPlanned aspect can only be completed by combining supplier and customer information. Only the supplier will create and update the Usage aspects. The missing information can be provided by the customer(s) with the help of notifications.
+
+For better understanding, simplified names "parents", "child", "customers" are used in the description.
+
+These expressions “parents”, “child” and “customers” can be translated into the attributes of the aspect model.
+
+Translation into SingleLevelUsageAsPlanned aspect:
+
+“parents” -> “catenaXId” in “parentItems”
+“child” -> overall “catenaXId” in aspect
+“customers” -> “businessPartner” in “customers”
+
+1. Supplier creates Digital Twin for his own part type or material with corresponding “part” aspect (partType). In addition, the supplier creates a singleLevelUsageAsPlanned aspect and attaches it to that Digital Twin. At this point of time the singleLevelUsageAsPlanned aspect cannot contain “parents” information, only “child” (unique ID of own product) and “customers” (BPNL of customers).
+2. The customer plans tp produce a product or material and creates a Digital Twin for it. When the customer plans to use the supplier part or material to produce the new product, he does not create an additional Digital Twin for the supplier product. Instead, the customer sends an appropriate notification to the supplier. This could happen when creating the singleLevelBomAsPlanned aspect, because at this point of time all information is available at the sender side. The customer sends a notification to the supplier, containing the missing “parents” information for that input product (“child”), both specified by the uniqueId, plus optional additional information like quantity and dates. “Parents” is the to be produced product at the customer, “child” is the to be used product coming from the supplier.
+3. Supplier receives notification from customer and updates own singleLevelUsageAsPlanned aspect with the “parents” and additional information, if provided, like quantity and dates.
+
+The customer MAY give access to the supplier for the Digital Twin and the partType aspect but it is not requested. The only information that is shared via notification is the catenaXID of the product to be used by the customer, plus quantity and date.
+
+The customer MAY NOT give access to the singleLevelBomAsPlanned aspect that belongs to the Digital Twin of his own product because it may also contain information relating to other suppliers that may not be shared.
 ### PartSiteInformationAsPlanned
 
 The aspect provides site related information for a given as planned item (i.e. a part type or part instance that is uniquely identifiable within Catena-X via its Catena-X ID). A site is a delimited geographical area where a legal entity does business. In the "as planned" lifecycle context all potentially related sites are listed including all sites where e.g. production of this part (type) is planned.
@@ -589,5 +635,57 @@ For the build-in parts (child items), their Unique ID is not known to the manufa
 - The next step is about getting the Unique ID of all built-in parts. There are two ways:
   - Unique IDs might for built-in parts might already be available locally if Unique ID Push is supported by the data provider and the suppliers of the built-in parts.
   - Query a supplier's Digital Twin Registry to find the digital twin for this built-in part
+
+### SingleLevelUsageAsBuilt
+
+The aspect provides the information in which parent part instance(s)/product(s) the given item is assembled into or used. This could be a 1:1 relationship in terms of e.g. a brake component or 1:n for e.g. coatings. The parent item must refer to an object from the as built lifecycle phase, the child item may refer to an object from the as built or the as planned lifecycle phase. If one input part instance is regarded as an alternative to another input part instance (from same or different supplier), the relation should still be built, but marked with "IsOnlyPotentialParent".
+
+Aspect model in GitHub:
+- Version 2.0.0: https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_usage_as_built/2.0.0
+
+##### Example: Submodel `SingleLevelUsageAsBuilt` for an Instance Part
+
+```json
+{
+  "catenaXId" : "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d",
+  "customers" : [ {
+    "parentItems" : [ {
+      "catenaXId" : "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d",
+      "quantity" : {
+        "quantityNumber" : 2.5,
+        "measurementUnit" : "unit:litre"
+      },
+      "createdOn" : "2022-02-03T14:48:54.709Z",
+      "lastModifiedOn" : "2022-02-03T14:48:54.709Z"
+    } ],
+    "businessPartner" : "BPNL50096894aNXY",
+    "createdOn" : "2022-02-03T14:48:54.709Z",
+    "lastModifiedOn" : "2022-02-03T14:48:54.709Z"
+  } ]
+}
+```
+
+#### Creation of Aspect Model SingleLevelUsageAsBuilt
+
+The SingleLevelUsageAsBuilt aspect can only be completed by combining supplier and customer information. Only the supplier will create and update the Usage aspects. The missing information can be provided by the customer(s) with the help of notifications.
+
+For better understanding, simplified names "parents", "child", "customers" are used in the description.
+
+These expressions “parents”, “child” and “customers” can be translated into the attributes of the aspect model.
+
+Translation into SingleLevelUsageAsBuilt aspect:
+
+“parents” -> “catenaXId” in “parentItems”
+“child” -> overall “catenaXId” in aspect
+“customers” -> “businessPartner” in “customers”
+
+1. Supplier creates Digital Twin for his own produced part or material with corresponding “part” aspect (partInstance or similar). In addition, the supplier creates a singleLevelUsageAsBuilt aspect and attaches it to that Digital Twin. At this point of time the singleLevelUsageAsBuilt aspect cannot contain “parents” information, only “child” (unique ID of own product) and “customers” (BPNL of customers).
+2. The customer produces a new product or material and creates a Digital Twin for it. When the customer uses the supplier part or material to produce the new product, he does not create an additional Digital Twin for the supplier product. Instead, the customer sends an appropriate notification to the supplier. This could happen when creating the singleLevelBomAsBuilt aspect, because at this point of time all information is available at the sender side. The customer sends a notification to the supplier, containing the missing “parents” information for that input product (“child”), both specified by the uniqueId, plus optional additional information like quantity and dates. “Parents” is the produced product at the customer, “child” is the used product coming from the supplier.
+3. Supplier receives notification from customer and updates own singleLevelUsageAsBuilt aspect with the “parents” and additional information, if provided, like quantity and dates.
+In case of a batch, the customer can use one batch to create several products. In that case, either several notifications can be sent, or one notification may contain several “parents” relations.
+In case of a batch, parts of it can also be sold to several customers. So, the supplier has to put several “customers” into the singleLevelUsageAsBuilt aspect and has to be ready to receive notifications from several customers that result in an update of the aspect
+The customer MAY give access to the supplier for the Digital Twin, partType or similar aspect but it is not requested. The only information that is shared via notification is the catenaXID of the product that has been manufactured by the customer plus quantity and date.
+
+The customer MAY NOT give access to the singleLevelBomAsBuilt aspect that belongs to the Digital Twin of his own produced product because it may also contain information relating to other suppliers that may not be shared.
 
 <Notice components={props.components} />

--- a/docs-kits/kits/Industry Core Kit/Software Development View/page_aspect-models.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/page_aspect-models.mdx
@@ -158,7 +158,7 @@ Aspect model in GitHub:
 ```
 #### Creation of Aspect Model SingleLevelUsageAsPlanned
 
-The SingleLevelUsageAsPlanned aspect can only be completed by combining supplier and customer information. Only the supplier will create and update the Usage aspects. The missing information can be provided by the customer(s) with the help of notifications.
+The SingleLevelUsageAsPlanned aspect can only be completed by combining supplier and customer information. Only the supplier will create and update the Usage aspects. The missing information can be provided by the customer(s) with the help of Unique Id Push notifications.
 
 For better understanding, simplified names "parents", "child", "customers" are used in the description.
 

--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_aspect-model-overview.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_aspect-model-overview.mdx
@@ -27,11 +27,11 @@ In the following section, all aspect models that are part of Industry Core are d
 | PartType | PartAsPlanned | 1.0.1 | 2.0.0 | Industry Core |
 | | SingleLevelBomAsPlanned | 1.1.0 | 2.0.0 | Industry Core |
 | | PartSiteInformationAsPlanned | 1.0.0 | | Industry Core |
-| | SingleLevelUsageAsPlanned | 1.1.0 | | Traceability |
+| | SingleLevelUsageAsPlanned | 1.1.0 | | Industry Core |
 | PartInstance | SerialPart | 1.0.1 | 2.0.0 | Industry Core |
 | | Batch | 2.0.0 | 2.0.1 | Industry Core |
 | | JustInSequencePart | 1.0.0 | 2.0.0 | Industry Core |
 | | SingleLevelBomAsBuilt | 1.0.0 | 2.0.0 | Industry Core |
 | | PartSiteInformationAsBuilt (shared aspect) | 1.0.0 | | Industry Core |
-| | SingleLevelUsageAsBuilt | 2.0.0 | | Traceability |
+| | SingleLevelUsageAsBuilt | 2.0.0 | | Industry Core |
 | | TractionBatteryCode | 1.0.0 | | Traceability |

--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
@@ -28,17 +28,21 @@ The solution is based on notification assets in the EDC (which is the same appro
 
 > :raised_hand: It is important to understand that the receiver creates EDC asset and policies, and thus, the sender of the Unique ID push notification must check during the EDC negotiation process if the conditions the receiver offers are acceptable for the sender.
 
-## Connect to Parent
+Currently there are two types of Unique Id Push Notifications available: "Connect to Parent" and "Connect to Child".
+
+##### Connect to Parent
 
 Unique ID Push notifications of type "connect-to-parent" are a way for a manufacturer to notify a customer as soon as possible when a new digital twin for a part is available.
 
 The sender of the notification is the supplier of a part item and the receiver of the notification is the customer of that part item. The Unique ID of that part is sent in the notification.
 
-## Connect to Child
+##### Connect to Child
 
-Unique ID Push notifications of type "connect-to-child" are a way for a manufacturer to notify a supplier when the supplier's part has been used (or is to be used in the case of part type) in the assembly or production of the manufacturer's product.
+Unique ID Push notifications of type "connect-to-child" are a way for a manufacturer to notify a supplier when the supplier's part has been used (or is to be used in the case of part type) in the assembly or production of the manufacturer's product. This will result in an update of the corresponding singleLevelUsage aspect at the supplier side.
 
 The sender of the notification is the customer of a part item or type and the receiver of the notification is the supplier of that part item or type. The Unique ID of that part, quantity and dates are sent in the notification.
+
+Connect to Child notifications can be applied to Digital Twins for part instances and for part types.
 
 #### Prerequisites and Constraints
 
@@ -48,7 +52,9 @@ For actively pushing Unique ID notifications, an EDC is required and the data pr
 
 Secondly, EDCs are being used for the exchange and it is currently required to offer a HTTP POST API to receive the Unique ID notifications push at the receiver's side. This API needs to be registered in the EDC Catalog as a data offer and requires specific properties to be set to standardized values, as this allows discoverability. Details still tbd.
 
-#### Unique ID Push Process Overview "connect-to-parent"
+#### Unique ID Push Process Overview
+
+##### Connect to Parent
 
 How the actual process is triggered is application specific. It is recommended to trigger the push of Unique IDs towards the customer after the Goods Issue has been booked, since commonly at that point the serial numbers/batch numbers of the parts being delivered are fixed in the logistics process and shall be contained in delivery documents, EDI Messages and/or any internal representation of the received items (non-Catena-X communication).
 
@@ -107,32 +113,50 @@ TraceCust -> TraceCust: link UUID to Traceability events/material
 @enduml
 -->
 
+##### Connect to Child
+
+How the actual process is triggered is application specific. It is recommended to trigger the push of "connect-to-child" towards the supplier earliest after the singleLevelBom aspect (AsBuilt oder AsPlanned) has been created, since at that point all relevant information is available. It is also possible to collect "connect-to-child" notification content at customer side and send this in a list to the supplier, e.g. once a day or once a week.
+
+The Unique ID push is initiated by the customer (acting as sender) towards their supplier (acting as receiver). The body information comes from the corresponding singleLevelBom aspect.
+
+Upon receipt of the message, the supplier needs to update the corresponding singleLevelUsageAspect(s) at his side. All information required can be taken from the body in the notification.
+
 #### Schema of Unique ID Push Notifications
 
-The notifications send to inform a customer about the creating of a new digital twin for one of the parts they received have a standardized format.
+##### Connect to Parent
+
+The notifications sent to inform a customer about the creation of a new digital twin for one of the parts they received have a standardized format.
 
 All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
 
 > Adding the customer part id to the notification is optional. The main reason for this is that it cannot be guaranteed that every manufacturer knows the customer part id for their parts. But, in case the manufacturer knows the customer and the corresponding customer part id of its part though, it is required to always add the customer part id to the notification.
 
-#### Notification Receiver (Customer)
+##### Connect to Child
+
+The notifications sent to inform a supplier about the usage of a part represented as a digital twin have a standardized format.
+
+All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
+
+#### Notification Receiver
 
 Here is a short overview what the receiver has to do when they want to support Unique Id Push notifications. This is an optional feature.
 
-- The receiver in this scenario is the customer of a part.
+- ** Connect to Parent ** The receiver in this scenario is the customer of a part.
+- ** Connect to Child ** The receiver in this scenario is the supplier of a part.
 - The receiver must create a EDC asset in their EDC that works as the endpoint for receiving notifications. Also, access & usage policies as described below must be configured.
 - The EDC in which the notification EDC asset was created must be registered at the Discovery Service (so that the sender can find the partner's EDC which should receive notifications)
 - When the Receiver receives a Unique Id Push notification, it must process this notification after it was received by the EDC (in a Backend Data Service)
 - How the Receiver processes the notification is up to them, but the following steps are recommended:
   - Verify the correctness of the data in the notification (i.e., the receiver is actually the customer of this part).
   - Store the notification data for later.
-  - Use this data when the digital twin for the part into which the delivered part is built into is created instead of doing a lookup to a supplier's Digital Twin Registry.
+  - **Connect to Parent** Use this data when the digital twin for the part into which the delivered part is built into is created instead of doing a lookup to a supplier's Digital Twin Registry.
+  - **Connect to Child** Use this data to update the corresponding singleLevelUsage aspect
 
 ##### EDC Asset
 
 For the EDC asset for receiving Unique ID Push notifications, the following conventions apply: 
 
-- The asset ID  must be "uniqueidpushnnotification-receipt".
+- The asset ID  must be "uniqueidpushnotification-receipt".
 - The following properties must be set for this asset:
   ```json
   {
@@ -146,7 +170,7 @@ For the EDC asset for receiving Unique ID Push notifications, the following conv
     "properties": {
       "dct:type": { "@id": "cx-taxo:ReceiveUniqueIdPushNotification" },
       "cx-common:version": "1.0",
-      "asset:prop:id": "uniqueidpushnnotification-receipt",
+      "asset:prop:id": "uniqueidpushnotification-receipt",
       "asset:prop:type": "notification.trace.uniqueidpush",
       "asset:prop:notificationtype": "uniqueidpush",
       "asset:prop:notificationmethod": "receive"
@@ -175,65 +199,34 @@ Keep in mind that usage policies currently aren't technically enforced by the ED
 
 The receiver must setup a backend data service that provides an HTTP Endpoint for notifications. All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
 
-#### Notification Sender (Manufacturer, Supplier)
+#### Notification Sender
 
 Here is a short overview what the sender has to do when they want to support Unique Id Push notifications. This is an optional feature.
 
+##### Connect to Parent (Sender = Supplier)
 - The Sender in this scenario is the manufacturer or supplier of a part.
 - When a new digital twin for a part was created, the manufacturer is responsible to send a Unique Id Push notification for this twin to the customer of this part.
 - It is recommended to send this notification as soon as possible, i.e., directly after the digital twin was created.
 
-##### Mapping BPN to EDC URL with Discovery Service API
-
-The sender must first find the EDC of the customer to which the notification should be sent to. For this, the BPN of the customer is required. With this, the Discovery Service can be used to query for all EDCs of the customer. After that, the data catalog of each of these EDCs must be queried for the notification EDC asset as described above. If this notification EDC asset is found in one of these EDCs, the notification can be sent.
-
-There should only be one EDC which provides the notification EDC asset for Unique Id Push. If more than one EDC (for the same BPN/partner) are found, this is considered a misconfiguration of the corresponding partner.
-
-#### Unique ID Push Process Overview "connect-to-child"
-
-How the actual process is triggered is application specific. It is recommended to trigger the push of "connect-to-child" towards the supplier earliest after the singleLevelBom... (AsBuilt oder AsPlanned) aspect has been created, since at that point all relevant information is available. It is also possible to collect "connect-to-child" notification content at customer side and send this in a list to the supplier, e.g. once a day or once a week.
-
-The Unique ID push is initiated by the customer (acting as sender) towards their supplier (acting as receiver). The body information comes from the corresponding singleLevelBom... aspect.
-
-Upon receipt of the message, the supplier needs to update the corresponding singleLevelUsageAspect(s) at his side. All information required can be taken from the body in the notification.
-
-#### Schema of Unique ID Push Notifications "connect-to-child"
-
-The notifications sent to inform a supplier about the usage of a part represented as a digital twin have a standardized format.
-
-All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
-
-#### Notification Receiver (Supplier)
-
-Here is a short overview what the receiver has to do when they want to support Unique Id Push notifications. This is an optional feature.
-
-- The receiver in this scenario is the supplier of a part.
-- The receiver must create a EDC asset in their EDC that works as the endpoint for receiving notifications. Also, access & usage policies as described below must be configured.
-- The EDC in which the notification EDC asset was created must be registered at the Discovery Service (so that the sender can find the partner's EDC which should receive notifications)
-- When the Receiver receives a Unique Id Push notification, it must process this notification after it was received by the EDC (in a Backend Data Service)
-- How the Receiver processes the notification is up to them, but the following steps are recommended:
-  - Verify the correctness of the data in the notification (i.e., the receiver is actually the supplier of this part).
-  - Store the notification data for later.
-  - Use this data to update the singleLevelUsage... aspects.
-
-##### EDC Asset and EDC Policies
-
-see above (link?)
-
-##### Backend Data Service to Process Unique ID Push Notifications
-
-The receiver must setup a backend data service that provides an HTTP Endpoint for notifications. All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
-
-#### Notification Sender (Customer)
-
-Here is a short overview what the sender has to do when they want to support Unique Id Push notifications. This is an optional feature.
-
-- The Sender in this scenario is the manufacturer or customer of a part.
-- When a new digital twin for a part was created, the manufacturer is responsible to send a Unique Id Push notification for this twin to the customer of this part.
-- It is recommended to send this notification as soon as possible, i.e., directly after the digital twin was created.
+##### Connect to Child (Sender = Customer)
+- The Sender in this scenario is the consumer of the supplied part.
+- When the supplied part is used in the production or assembly at the customer side, the customer is responsible to send a Unique Id Push notification for the twin of the used part to the supplier of this part. This is known by the customer when the singleLevelBom aspect is created or updated.
+- This notification can be sent immediately or collected to be sent when convenient, e.g. once a day or once a week, depending on the use case.
 
 ##### Mapping BPN to EDC URL with Discovery Service API
 
-The sender must first find the EDC of the customer to which the notification should be sent to. For this, the BPN of the customer is required. With this, the Discovery Service can be used to query for all EDCs of the customer. After that, the data catalog of each of these EDCs must be queried for the notification EDC asset as described above. If this notification EDC asset is found in one of these EDCs, the notification can be sent.
+**Connect to Parent** The sender must first find the EDC of the customer (receiver) to which the notification should be sent to. For this, the BPN of the customer is required.
+
+**Connect to Child** After creating the singleLevelBom aspect the sender should already know the BPN of the supplier (receiver).
+
+With this, the Discovery Service can be used to query for all EDCs of the receiver. After that, the data catalog of each of these EDCs must be queried for the notification EDC asset as described above. If this notification EDC asset is found in one of these EDCs, the notification can be sent.
 
 There should only be one EDC which provides the notification EDC asset for Unique Id Push. If more than one EDC (for the same BPN/partner) are found, this is considered a misconfiguration of the corresponding partner.
+
+
+
+
+
+
+
+

--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
@@ -22,21 +22,33 @@ This work is licensed under the CC-BY-4.0 (https://creativecommons.org/licenses/
 
 ### Unique ID Push
 
-Unique ID Push notifications are a way for a manufacturer to notify a customer as soon as possible when a new digital twin for a part is available.
+Unique ID Push notifications provide the possibility to push specific information to a business partner in the value chain (one level up or one level down). This can help to provide faster information to reduce necessary information collection activities (connect-to-parent) or to provide information that is not available at all at the receiver side (connect-to-child).
 
-The solution is based on notification assets in the EDC (which is the same approach that is used for quality alerts & investigations). The customer creates a notification asset in the EDC and the customer's suppliers send their notifications (with the Unique Id) to this notification asset. As this notification asset is a general EDC asset - as for all EDC assets - access policies, usage policies and contract definitions must be created.
+The solution is based on notification assets in the EDC (which is the same approach that is used for quality alerts & investigations). The notification receiver creates a notification asset in the EDC and the notification sender sends his notifications to this notification asset. As this notification asset is a general EDC asset - as for all EDC assets - access policies, usage policies and contract definitions must be created.
 
-> :raised_hand: It is important to understand that the customer (receiver) creates EDC asset and policies, and thus, the supplier (sender) of the Unique ID push notification must check during the EDC negotiation process if the conditions the receiver offers are acceptable for the sender.
+> :raised_hand: It is important to understand that the receiver creates EDC asset and policies, and thus, the sender of the Unique ID push notification must check during the EDC negotiation process if the conditions the receiver offers are acceptable for the sender.
+
+## Connect to Parent
+
+Unique ID Push notifications of type "connect-to-parent" are a way for a manufacturer to notify a customer as soon as possible when a new digital twin for a part is available.
+
+The sender of the notification is the supplier of a part item and the receiver of the notification is the customer of that part item. The Unique ID of that part is sent in the notification.
+
+## Connect to Child
+
+Unique ID Push notifications of type "connect-to-child" are a way for a manufacturer to notify a supplier when the supplier's part has been used (or is to be used in the case of part type) in the assembly or production of the manufacturer's product.
+
+The sender of the notification is the customer of a part item or type and the receiver of the notification is the supplier of that part item or type. The Unique ID of that part, quantity and dates are sent in the notification.
 
 #### Prerequisites and Constraints
 
-In order to be able to push Unique ID(s) of part(s) to the correct partner, it is required that the data provider (manufacturer) pushing the Unique IDs is aware of the BPN of the actual receiver of the part (i.e., the customer) or has enough data in its context to use BPDM functions to determine the BPN Number of the receiver.
+In order to be able to push Unique ID(s) of part(s) to the correct partner, it is required that the sender pushing the Unique ID notification is aware of the BPN of the receiver of the notification or has enough data in its context to use BPDM functions to determine the BPN Number of the receiver.
 
-For actively pushing Unique IDs, an EDC is required and the data provider needs to be enabled to execute the complete process including EDC communication and HTTP Push (i.e., HTTP POST) of the payload.
+For actively pushing Unique ID notifications, an EDC is required and the data provider needs to be enabled to execute the complete process including EDC communication and HTTP Push (i.e., HTTP POST) of the payload.
 
-Secondly, EDCs are being used for the exchange and it is currently required to offer a HTTP POST API to receive the Unique IDs push at the receiver's side. This API needs to be registered in the EDC Catalog as a data offer and requires specific properties to be set to standardized values, as this allows discover-ability. Details still tbd.
+Secondly, EDCs are being used for the exchange and it is currently required to offer a HTTP POST API to receive the Unique ID notifications push at the receiver's side. This API needs to be registered in the EDC Catalog as a data offer and requires specific properties to be set to standardized values, as this allows discoverability. Details still tbd.
 
-#### Unique ID Push Process Overview
+#### Unique ID Push Process Overview "connect-to-parent"
 
 How the actual process is triggered is application specific. It is recommended to trigger the push of Unique IDs towards the customer after the Goods Issue has been booked, since commonly at that point the serial numbers/batch numbers of the parts being delivered are fixed in the logistics process and shall be contained in delivery documents, EDI Messages and/or any internal representation of the received items (non-Catena-X communication).
 
@@ -168,6 +180,55 @@ The receiver must setup a backend data service that provides an HTTP Endpoint fo
 Here is a short overview what the sender has to do when they want to support Unique Id Push notifications. This is an optional feature.
 
 - The Sender in this scenario is the manufacturer or supplier of a part.
+- When a new digital twin for a part was created, the manufacturer is responsible to send a Unique Id Push notification for this twin to the customer of this part.
+- It is recommended to send this notification as soon as possible, i.e., directly after the digital twin was created.
+
+##### Mapping BPN to EDC URL with Discovery Service API
+
+The sender must first find the EDC of the customer to which the notification should be sent to. For this, the BPN of the customer is required. With this, the Discovery Service can be used to query for all EDCs of the customer. After that, the data catalog of each of these EDCs must be queried for the notification EDC asset as described above. If this notification EDC asset is found in one of these EDCs, the notification can be sent.
+
+There should only be one EDC which provides the notification EDC asset for Unique Id Push. If more than one EDC (for the same BPN/partner) are found, this is considered a misconfiguration of the corresponding partner.
+
+#### Unique ID Push Process Overview "connect-to-child"
+
+How the actual process is triggered is application specific. It is recommended to trigger the push of "connect-to-child" towards the supplier earliest after the singleLevelBom... (AsBuilt oder AsPlanned) aspect has been created, since at that point all relevant information is available. It is also possible to collect "connect-to-child" notification content at customer side and send this in a list to the supplier, e.g. once a day or once a week.
+
+The Unique ID push is initiated by the customer (acting as sender) towards their supplier (acting as receiver). The body information comes from the corresponding singleLevelBom... aspect.
+
+Upon receipt of the message, the supplier needs to update the corresponding singleLevelUsageAspect(s) at his side. All information required can be taken from the body in the notification.
+
+#### Schema of Unique ID Push Notifications "connect-to-child"
+
+The notifications sent to inform a supplier about the usage of a part represented as a digital twin have a standardized format.
+
+All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
+
+#### Notification Receiver (Supplier)
+
+Here is a short overview what the receiver has to do when they want to support Unique Id Push notifications. This is an optional feature.
+
+- The receiver in this scenario is the supplier of a part.
+- The receiver must create a EDC asset in their EDC that works as the endpoint for receiving notifications. Also, access & usage policies as described below must be configured.
+- The EDC in which the notification EDC asset was created must be registered at the Discovery Service (so that the sender can find the partner's EDC which should receive notifications)
+- When the Receiver receives a Unique Id Push notification, it must process this notification after it was received by the EDC (in a Backend Data Service)
+- How the Receiver processes the notification is up to them, but the following steps are recommended:
+  - Verify the correctness of the data in the notification (i.e., the receiver is actually the supplier of this part).
+  - Store the notification data for later.
+  - Use this data to update the singleLevelUsage... aspects.
+
+##### EDC Asset and EDC Policies
+
+see above (link?)
+
+##### Backend Data Service to Process Unique ID Push Notifications
+
+The receiver must setup a backend data service that provides an HTTP Endpoint for notifications. All endpoints as well as the schema of the notification below are described in detail in the [Unique ID Push API documentation](Unique%20ID%20Push%20API/unique-id-push-notification-api).
+
+#### Notification Sender (Customer)
+
+Here is a short overview what the sender has to do when they want to support Unique Id Push notifications. This is an optional feature.
+
+- The Sender in this scenario is the manufacturer or customer of a part.
 - When a new digital twin for a part was created, the manufacturer is responsible to send a Unique Id Push notification for this twin to the customer of this part.
 - It is recommended to send this notification as soon as possible, i.e., directly after the digital twin was created.
 

--- a/docs-kits/kits/Industry Core Kit/page_changelog.mdx
+++ b/docs-kits/kits/Industry Core Kit/page_changelog.mdx
@@ -45,7 +45,7 @@ Compatible for release 24.05.
   - **Digital Twins:**
     - ./.
   - **Aspect Models:**
-    - ./.
+    - Added SingleLevelUsageAsBuilt and SingleLevelUsageAsPlanned aspects
   - **Policies:**
     - ./.
 
@@ -61,7 +61,7 @@ Compatible for release 24.05.
   - **Digital Twins:**
     - ./.
   - **Aspect Models:**
-    - ./.
+    - Enhanced Unique Id Push Notification with two notification types, one for connect to parent and one for connect to child
   - **Policies:**
     - ./.
 


### PR DESCRIPTION
I added the aspect models singleLevelUsageAsBuilt and singleLevelUsageAsPlanned with descriptions, enhanced the UniqueIdPush Notification part and the changelog.
The aspect models still have to be updated to the final version to be published in the standard, with links and examples. The corresponding openAPI specification also still has to be added.