### PR TITLE
docs: Removed Usage aspects from Traceability

### DIFF
--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_aspect-model-overview.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_aspect-model-overview.mdx
@@ -27,11 +27,11 @@ In the following section, all aspect models that are part of Industry Core are d
 | PartType | PartAsPlanned | 1.0.1 | 2.0.0 | Industry Core |
 | | SingleLevelBomAsPlanned | 1.1.0 | 2.0.0 | Industry Core |
 | | PartSiteInformationAsPlanned | 1.0.0 | | Industry Core |
-| | SingleLevelUsageAsPlanned | 1.1.0 | | Traceability |
+| | SingleLevelUsageAsPlanned | 1.1.0 | | Industry Core |
 | PartInstance | SerialPart | 1.0.1 | 2.0.0 | Industry Core |
 | | Batch | 2.0.0 | 2.0.1 | Industry Core |
 | | JustInSequencePart | 1.0.0 | 2.0.0 | Industry Core |
 | | SingleLevelBomAsBuilt | 1.0.0 | 2.0.0 | Industry Core |
 | | PartSiteInformationAsBuilt (shared aspect) | 1.0.0 | | Industry Core |
-| | SingleLevelUsageAsBuilt | 2.0.0 | | Traceability |
+| | SingleLevelUsageAsBuilt | 2.0.0 | | Industry Core |
 | | TractionBatteryCode | 1.0.0 | | Traceability |

--- a/docs-kits/kits/Traceability Kit/Software Development View/part_aspect-models.mdx
+++ b/docs-kits/kits/Traceability Kit/Software Development View/part_aspect-models.mdx
@@ -28,33 +28,6 @@ Aspect models are mostly easy to create by transforming a company's internal dat
 
 <AspectModelOverview components={props.components} />
 
-### SingelLevelUsageAsPlanned
-
-The aspect provides the information in which parent part(s)/product(s) the given item is assembled in. This could be a 1:1 relationship in terms of a e.g. a brake component or 1:n for e.g. coatings. The given item as well as the parent item must refer to an object from as planned lifecycle phase. If multiple versions of parent parts exist that the child part can be assembled into, all versions of the parent part are included in the usage list.
-
-Aspect model in GitHub:
-- Version 1.1.0: https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_usage_as_planned/1.1.0
-
-
-##### Example: Submodel `SingleLevelUsageAsPlanned` for a Catalog Part
-
-```json
-{
-  "parentParts": [
-    {
-      "parentCatenaXId": "urn:uuid:c8B01D5A-ce0B-6Dd4-5bA0-A3e3fcE9cA93",
-      "quantity": {
-        "quantityNumber": 2.5,
-        "measurementUnit": "unit:litre"
-      },
-      "createdOn": "2022-02-03T14:48:54.709Z",
-      "lastModifiedOn": "2022-02-03T14:48:54.709Z"
-    }
-  ],
-  "catenaXId": "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d"
-}
-```
-
 ### TractionBatteryCode
 
 The aspect provides the information of the Traction battery code of a battery cell, a battery module or a battery pack according to the chinese standard GB/T 34014-2017. Furthermore, it provides the traction battery codes for the assembled sub parts of the component, e.g.  Traction battery code of a battery module plus all the traction battery codes of the assembled battery cells of this battery module.
@@ -126,32 +99,5 @@ Aspect model in GitHub:
       ]
     }
   ]
-}
-```
-
-### SingleLevelUsageAsBuilt
-
-Aspect model in GitHub:
-- Version 2.0.0: https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.single_level_usage_as_built/2.0.0
-
-##### Example: Submodel `SingleLevelUsageAsBuilt` for a Instance Part
-
-```json
-{
-  "catenaXId" : "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d",
-  "customers" : [ {
-    "parentItems" : [ {
-      "catenaXId" : "urn:uuid:055c1128-0375-47c8-98de-7cf802c3241d",
-      "quantity" : {
-        "quantityNumber" : 2.5,
-        "measurementUnit" : "unit:litre"
-      },
-      "createdOn" : "2022-02-03T14:48:54.709Z",
-      "lastModifiedOn" : "2022-02-03T14:48:54.709Z"
-    } ],
-    "businessPartner" : "BPNL50096894aNXY",
-    "createdOn" : "2022-02-03T14:48:54.709Z",
-    "lastModifiedOn" : "2022-02-03T14:48:54.709Z"
-  } ]
 }
 ```

--- a/docs-kits/kits/Traceability Kit/page_architecture-view.mdx
+++ b/docs-kits/kits/Traceability Kit/page_architecture-view.mdx
@@ -85,10 +85,10 @@ The following diagram shows a basic data processing flow how a company's interna
 Data provisioning of Traceabilty is built on the data provisioning of the [Industry Core KIT](../Industry%20Core%20Kit/Architecture%20View%20Industry%20Core%20Kit), i.e., Traceability extends the digital twins PartType and PartInstance with additional aspect models:
 
 - Digital Twin "PartType"
-  - Aspect model ["SingelLevelUsageAsPlanned"](../Traceability%20Kit/Software%20Development%20View/Data%20Provider%20Development%20View%20Traceability%20Kit#singellevelusageasplanned)
+
 - Digital Twin "PartInstance"
   - Aspect model ["TractionBatteryCode"](../Traceability%20Kit/Software%20Development%20View/Data%20Provider%20Development%20View%20Traceability%20Kit#tractionbatterycode)
-  - Aspect model ["SingleLevelUsageAsBuilt"](../Traceability%20Kit/Software%20Development%20View/Data%20Provider%20Development%20View%20Traceability%20Kit#singlelevelusageasbuilt)
+
 
 Details about these aspect models, i.e., the SAMM data model as well as example data, can be found in the [Developer View](../Traceability%20Kit/Software%20Development%20View/Data%20Provider%20Development%20View%20Traceability%20Kit).
 

--- a/docs-kits/kits/Traceability Kit/page_changelog.mdx
+++ b/docs-kits/kits/Traceability Kit/page_changelog.mdx
@@ -72,7 +72,7 @@ Compatible for release 24.05.
   - ./.
 - **Development View:**
   - **Data Provider:**
-    - ./.
+    - Removed aspects singleLevelUsageAsPlanned and singleLevelUsageAsBuilt, because thes aspects moved to the Industry Core
   - **App Provider:**
     - ./.
 


### PR DESCRIPTION
I removed the usage aspects from the Traceability KIT, updated the aspect overview (in Industry Core) and the changelog in Traceability