### PR TITLE
Fix cx-taxo unique id push

### DIFF
--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
@@ -173,8 +173,8 @@ For the EDC asset for receiving Unique ID Push notifications, the following prop
 Properties `https://purl.org/dc/terms/type` and `https://w3id.org/catenax/ontology/common#version` are used to classify the asset and are explained in the [Digital Twin KIT](https://eclipse-tractusx.github.io/docs-kits/kits/Digital%20Twin%20Kit/Software%20Development%20View/Specification%20Digital%20Twin%20KIT#registration-at-edc) in more detail.
 
 For `{{ _.notificationType }}`, use
-- `https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification` for the Connect-To-Parent notification asset and
--  `https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToChildNotification` for the Connect-To-Child notification asset.
+- `UniqueIdPushConnectToParentNotification` for the Connect-To-Parent notification asset and
+- `UniqueIdPushConnectToChildNotification` for the Connect-To-Child notification asset.
 
 > :raised_hand: Note that the API version can be different depending on what Unique ID Push API version your company supports.
 


### PR DESCRIPTION
The cx-taxo namespace is already defined in the context. Thus, the URL can be removed later so that the variable values only contain the part after the # symbol.